### PR TITLE
Issue #279 unfurling FIXED

### DIFF
--- a/publication/publication-rs-for-all.xml
+++ b/publication/publication-rs-for-all.xml
@@ -8,7 +8,7 @@
     <html>
         <platform host="web" />
         <!-- knowled checkpoints interfere with ActiveCode problems -->
-        <knowl exercise-inline="no" example="no" listing="yes" />
+        <knowl exercise-inline="no" example="no" listing="no" />
     </html>
 
     


### PR DESCRIPTION
## Description 

The issue spanning the book, with all the exercises hidden under a listing that was easy to miss, is now fixed. 

## Issue Fix

fixes #279 

## Screenshot of Fix:

<img width="1746" height="842" alt="image" src="https://github.com/user-attachments/assets/1ff59e23-f334-442c-82b6-723ee53a0aea" />

## Tested

local build 

## Reviewed By

Galina


