### PR TITLE
ISSUE 278 FIXED: the paragraph problems in 3.1 as per issue 278

### DIFF
--- a/pretext/AlgorithmAnalysis/WhatIsAlgorithmAnalysis.ptx
+++ b/pretext/AlgorithmAnalysis/WhatIsAlgorithmAnalysis.ptx
@@ -17,16 +17,12 @@
             programming language. There may be many programs for the same algorithm,
             depending on the programmer and the programming language being used.</p>
   <p>To explore this difference further, consider the function shown in
-            <xref ref="lst-sum0"/>. This function solves a familiar problem, computing the
+            <xref ref="lst-sum0" visual="hybrid"/>. This function solves a familiar problem, computing the
             sum of the first <em>n</em> integers. The algorithm uses the idea of an
             accumulator variable that is initialized to 0. The solution then
             iterates through the <em>n</em> integers, adding each to the accumulator.</p>
-  <p xml:id="lst-sum0" names="lst_sum0">
     
-  </p>
-  <exercise>
-    
-      <listing xml:id="ec1_py">
+      <listing  xml:id="lst-sum0" names="lst_sum0">
         <program interactive="activecode" language="python">
           <code>
 # adds the sum of (n + n-1 + n-2 ...)
@@ -44,20 +40,15 @@ main()
         </program>
       </listing>
     
-  </exercise>
-  <p>Now look at the function in <xref ref="lst-sum2"/>.
+ <p>Now look at the function in <xref ref="lst-sum2"/>.
             At first glance it may look
             strange, but upon further inspection you can see that this function is
             essentially doing the same thing as the previous one. The reason this is
             not obvious is poor coding. We did not use good identifier names to
             assist with readability, and we used an extra assignment statement
             during the accumulation step that was not really necessary.</p>
-  <p xml:id="lst-sum2" names="lst_sum2">
     
-  </p>
-  <exercise>
-    
-      <listing xml:id="ec2_py">
+      <listing xml:id="lst-sum2" names="lst_sum2">
         <program interactive="activecode" language="python">
           <code>
 #Performs same function as the first listing, but is less descriptive
@@ -78,8 +69,7 @@ main()
         </program>
       </listing>
     
-  </exercise>
-  <p>The question we raised earlier asked whether one function is better than
+\  <p>The question we raised earlier asked whether one function is better than
             another. The answer depends on your criteria. The function <c>sumOfN</c> is
             certainly better than the function <c>foo</c> if you are concerned with
             readability. In this course, however, we are also interested in characterizing
@@ -111,12 +101,8 @@ main()
             arbitrary starting point. By calling this function twice, at the beginning
             and at the end, and then computing the difference, we can get an exact
             number of seconds (fractions in most cases) for execution.</p>
-  <p xml:id="lst-sum11" names="lst_sum11">
     
-  </p>
-  <exercise>
-    
-      <listing xml:id="ec2py">
+      <listing xml:id="lst-sum11" names="lst_sum11">
         <program interactive="activecode" language="python">
           <code>
 import time
@@ -145,13 +131,12 @@ main()
         </program>
       </listing>
     
-  </exercise>
   <p><xref ref="lst-sum11"/> shows the original <c>sumOfN</c> function with the timing
             calls embedded before and after the summation. The function returns the amount of time (in seconds)
             required for the calculation.</p>
   <exercise>
     <statement>
-      <p>Q-4: In <xref ref="lst-sum11"/> above, how many times is the <title_reference>theSum = theSum + 1</title_reference> line executed? <var/>  </p>
+      <p>In <xref ref="lst-sum11"/> above, how many times is the <title_reference>theSum = theSum + 1</title_reference> line executed? <var/>  </p>
     </statement>
     <setup>
       <var>
@@ -190,7 +175,7 @@ main()
                 Similarly, <m>\sum_{i=2}^{4} i^2</m> means <m>2^2+3^2+4^2</m>.</p>
     <exercise label="somemath1">
       <statement>
-        <p>Q-5: Compute the result of <m>\sum_{i=1}^{3} i^3</m></p>
+        <p>Compute the result of <m>\sum_{i=1}^{3} i^3</m></p>
       </statement>
       <choices>
         <choice>
@@ -264,7 +249,6 @@ main()
     <p>We see this in <xref ref="lst-sum3"/>,
                 which shows <c>sumOfN3</c>
                 taking advantage of the formula we just developed.</p>
-    <exercise>
       
         <listing xml:id="lst-sum3">
           <program interactive="activecode" language="python">
@@ -282,7 +266,6 @@ main()
           </program>
         </listing>
       
-    </exercise>
     <p>If we do the same benchmark measurement for <c>sumOfN3</c>,
                 using the value  10,000 for <c>n</c> and we get the following result:</p>
     <pre>Sum is 50005000 required 0.000000 seconds


### PR DESCRIPTION
## Description 

Instead of displaying an empty paragraph block, it now displays a listing and, when pressed, gives you a knowl of the code. (A box that opens). This is a temporary fix until we find out whether there is a way to automatically hyperlink it when clicked, but it doesn't work. 

## What Issue? 

fixes #278 

## Screenshot 
<img width="1753" height="873" alt="image" src="https://github.com/user-attachments/assets/57da9485-40d8-49d6-8daf-36e385e96fb5" />

when pressed: 
<img width="1734" height="985" alt="image" src="https://github.com/user-attachments/assets/07cae9f1-4967-438b-a21b-ccc4ed33bccf" />

## Tested?

local build 

## Reviewed 

Galina





