### PR TITLE
ISSUE 277 FIXED: math block is displayed correctly in 3.3.1

### DIFF
--- a/pretext/AlgorithmAnalysis/AlgorithmAnalysisExamples.ptx
+++ b/pretext/AlgorithmAnalysis/AlgorithmAnalysisExamples.ptx
@@ -73,8 +73,15 @@ main()
                     array will be visited once to match a character from <c>s1</c>. The number
                     of visits then becomes the sum of the integers from 1 to <em>n</em>. We stated
                     earlier that this can be written as:</p>
-      <math_block docname="AlgorithmAnalysis/AlgorithmAnalysisExamples"  nowrap="False" number="True" xml:space="preserve">\sum_{i=1}^{n} i &amp;= \frac {n(n+1)}{2} \\
-                 &amp;= \frac {1}{2}n^{2} + \frac {1}{2}n</math_block>
+
+  <p>
+    <md>
+        <mrow>\sum_{i=1}^{n} i \amp = \frac {n(n+1)}{2}</mrow>
+        <mrow> \amp = \frac {1}{2}n^{2} + \frac {1}{2}n</mrow>
+    </md>
+  </p>
+
+  
       <p>As <m>n</m> gets large, the <m>n^{2}</m> term will dominate the
                     <m>n</m> term and the <m>\frac {1}{2}</m> can be ignored.
                     Therefore, this solution is <m>O(n^{2})</m>.</p>


### PR DESCRIPTION
## Description 

Math in this section was not displayed correctly, resulting in a display error.  

## Issue Fix 

fixes #277 

## Screenshot 

<img width="870" height="349" alt="image" src="https://github.com/user-attachments/assets/e1e84bcd-19fb-4695-9e0d-bd46704b2ab6" />

## Tested

Local build 

## Reviewed By 

Galina 
